### PR TITLE
Update Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,7 @@
 tap "homebrew/cask"
 tap "homebrew/homebrew-bundle"
 tap "JuulLabs-OSS/mynewt"
+tap "homebrew/cask-drivers"
 
 brew "mynewt-newt@1.7"
 brew "carthage"


### PR DESCRIPTION
Add 'homebrew/cask-drivers' repository to Brewfile.
This repository contains one of our dependencies: 'segger-jlink'.