### PR TITLE
[Android] support public fitbit gattlink service UUID

### DIFF
--- a/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/bt/GlobalBluetoothGattInitializer.kt
+++ b/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/bt/GlobalBluetoothGattInitializer.kt
@@ -11,6 +11,7 @@ import com.fitbit.bluetooth.fbgatt.rx.BaseFitbitGattCallback
 import com.fitbit.bluetooth.fbgatt.rx.server.BitGattServer
 import com.fitbit.goldengate.bt.gatt.GattServerListenerRegistrar
 import com.fitbit.goldengate.bt.gatt.server.services.gattcache.GattCacheServiceHandler
+import com.fitbit.goldengate.bt.gatt.server.services.gattlink.FitbitGattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.GattlinkService
 import com.fitbit.linkcontroller.LinkControllerProvider
 import io.reactivex.disposables.CompositeDisposable
@@ -33,7 +34,7 @@ internal class GlobalBluetoothGattInitializer(
     private val gattServerListenerRegistrar: GattServerListenerRegistrar = GattServerListenerRegistrar,
     private val linkControllerProvider: LinkControllerProvider = LinkControllerProvider.INSTANCE,
     private val gattCacheServiceHandler: GattCacheServiceHandler = GattCacheServiceHandler(),
-    private val gattlinkServiceProvider: () -> GattlinkService = { GattlinkService() }
+    private val gattlinkServiceProvider: () -> FitbitGattlinkService = { FitbitGattlinkService() }
 ) {
 
     private val disposeBag = CompositeDisposable()

--- a/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/bt/gatt/server/services/gattlink/FitbitGattlinkService.kt
+++ b/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/bt/gatt/server/services/gattlink/FitbitGattlinkService.kt
@@ -1,0 +1,28 @@
+package com.fitbit.goldengate.bt.gatt.server.services.gattlink
+
+import android.bluetooth.BluetoothGattService
+import java.util.UUID
+
+/**
+ * Represents the Gattlink Service hosted on mobile that allows reliable streaming of
+ * arbitrary data over a BLE connection using the GATT protocol, with support for BLE/GATT stacks
+ * that don't always have the necessary support for writing GATT characteristics back-to-back
+ * without dropping data
+ *
+ * Fitbit has registered the Gattlink Service to SIG with 16-bit UUID 0xFD62, which has a different
+ * service UUID from original one.
+ * https://www.bluetooth.com/specifications/assigned-numbers/16-bit-uuids-for-members/
+ */
+class FitbitGattlinkService : BluetoothGattService(
+    uuid,
+    BluetoothGattService.SERVICE_TYPE_PRIMARY) {
+
+    init {
+        addCharacteristic(ReceiveCharacteristic())
+        addCharacteristic(TransmitCharacteristic())
+    }
+
+    companion object {
+        val uuid: UUID = UUID.fromString("0000FD62-0000-1000-8000-00805F9B34FB")
+    }
+}

--- a/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/bt/gatt/server/services/gattlink/GattlinkService.kt
+++ b/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/bt/gatt/server/services/gattlink/GattlinkService.kt
@@ -11,6 +11,9 @@ import java.util.UUID
  * arbitrary data over a BLE connection using the GATT protocol, with support for BLE/GATT stacks
  * that don't always have the necessary support for writing GATT characteristics back-to-back
  * without dropping data
+ *
+ * Note: Fitbit has registered the new public [FitbitGattlinkService] to the bluetooth SIG.
+ * From now on, new trackers will host [FitbitGattlinkService] instead of [GattlinkService]
  */
 class GattlinkService : BluetoothGattService(
         uuid,

--- a/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/bt/gatt/server/services/gattlink/listeners/TransmitCharacteristicSubscriptionListener.kt
+++ b/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/bt/gatt/server/services/gattlink/listeners/TransmitCharacteristicSubscriptionListener.kt
@@ -16,6 +16,7 @@ import com.fitbit.bluetooth.fbgatt.rx.GattCharacteristicSubscriptionStatus
 import com.fitbit.bluetooth.fbgatt.rx.server.GattServerResponseSenderProvider
 import com.fitbit.bluetooth.fbgatt.rx.server.listeners.BaseServerConnectionEventListener
 import com.fitbit.goldengate.bindings.util.hexString
+import com.fitbit.goldengate.bt.gatt.server.services.gattlink.FitbitGattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.GattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.TransmitCharacteristic
 import io.reactivex.Observable
@@ -76,7 +77,8 @@ class TransmitCharacteristicSubscriptionListener @VisibleForTesting internal con
             """)
 
         when (result.serviceUuid) {
-            GattlinkService.uuid -> handleGattlinkServerDescriptorWriteRequest(device, result, connection)
+            GattlinkService.uuid,
+            FitbitGattlinkService.uuid -> handleGattlinkServerDescriptorWriteRequest(device, result, connection)
             else -> Timber.d("Ignoring onServerDescriptorWriteRequest call for unsupported service: ${result.serviceUuid}")
         }
     }

--- a/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/node/LinkupWithPeerNodeHandler.kt
+++ b/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/node/LinkupWithPeerNodeHandler.kt
@@ -8,6 +8,7 @@ import com.fitbit.bluetooth.fbgatt.rx.client.GattServiceRefresher
 import com.fitbit.bluetooth.fbgatt.rx.client.PeerGattServiceSubscriber
 import com.fitbit.goldengate.bt.gatt.client.services.GattDatabaseValidator
 import com.fitbit.goldengate.bt.gatt.client.services.GenericAttributeService
+import com.fitbit.goldengate.bt.gatt.server.services.gattlink.FitbitGattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.GattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.TransmitCharacteristic
 import com.fitbit.goldengate.bt.gatt.util.dumpServices
@@ -16,6 +17,7 @@ import io.reactivex.Flowable
 import io.reactivex.Scheduler
 import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -107,10 +109,15 @@ internal class LinkupWithPeerNodeHandler(
         return Completable.defer {
             peerGattServiceSubscriber.subscribe(
                 peer,
-                GattlinkService.uuid,
+                getRemoteGattLinkServiceUUID(peer),
                 TransmitCharacteristic.uuid
             )
         }
+    }
+
+    private fun getRemoteGattLinkServiceUUID(peer: BitGattPeer): UUID {
+        return if (peer.gattConnection.getRemoteGattService(GattlinkService.uuid) != null)
+            GattlinkService.uuid else FitbitGattlinkService.uuid
     }
 
     private fun refreshServices(peer: BitGattPeer): Completable =

--- a/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/node/LocalGattlinkNodeDataSender.kt
+++ b/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/node/LocalGattlinkNodeDataSender.kt
@@ -6,19 +6,22 @@ package com.fitbit.goldengate.node
 import com.fitbit.bluetooth.fbgatt.FitbitGatt
 import com.fitbit.bluetooth.fbgatt.GattConnection
 import com.fitbit.bluetooth.fbgatt.rx.server.GattCharacteristicNotifier
+import com.fitbit.goldengate.bt.gatt.server.services.gattlink.FitbitGattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.GattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.TransmitCharacteristic
 import io.reactivex.Completable
+import java.util.UUID
 
 /**
  * Use Gattlink service hosted on local GATT server for sending data via its Tx characteristic
  */
 internal class LocalGattlinkNodeDataSender(
     private val connection: GattConnection,
+    private val serviceId: UUID,
     fitbitGatt: FitbitGatt = FitbitGatt.getInstance(),
     private val gattCharacteristicNotifier: GattCharacteristicNotifier = GattCharacteristicNotifier(connection.device, fitbitGatt)
 ) : NodeDataSender {
 
     override fun send(data: ByteArray): Completable =
-        gattCharacteristicNotifier.notify(GattlinkService.uuid, TransmitCharacteristic.uuid, data)
+        gattCharacteristicNotifier.notify(serviceId, TransmitCharacteristic.uuid, data)
 }

--- a/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/node/NodeDataReceiverProvider.kt
+++ b/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/node/NodeDataReceiverProvider.kt
@@ -4,6 +4,7 @@
 package com.fitbit.goldengate.node
 
 import com.fitbit.bluetooth.fbgatt.GattConnection
+import com.fitbit.goldengate.bt.gatt.server.services.gattlink.FitbitGattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.GattlinkService
 import timber.log.Timber
 
@@ -16,7 +17,8 @@ class NodeDataReceiverProvider {
      * Provides [NodeDataReceiver] to use given [connection]
      */
     fun provide(connection: GattConnection): NodeDataReceiver {
-        return if (connection.getRemoteGattService(GattlinkService.uuid) != null) {
+        return if (connection.getRemoteGattService(GattlinkService.uuid) != null ||
+            connection.getRemoteGattService(FitbitGattlinkService.uuid) != null) {
             Timber.d("Using GattlinkService hosted from remote device for receiving data")
             RemoteGattlinkNodeDataReceiver(connection)
         } else {

--- a/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/node/NodeDataSenderProvider.kt
+++ b/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/node/NodeDataSenderProvider.kt
@@ -5,6 +5,7 @@ package com.fitbit.goldengate.node
 
 import com.fitbit.bluetooth.fbgatt.FitbitGatt
 import com.fitbit.bluetooth.fbgatt.GattConnection
+import com.fitbit.goldengate.bt.gatt.server.services.gattlink.FitbitGattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.GattlinkService
 import timber.log.Timber
 
@@ -17,12 +18,19 @@ class NodeDataSenderProvider(private val fitbitGatt: FitbitGatt = FitbitGatt.get
      * Provides [NodeDataSender] to use for sending data for given [connection]
      */
     fun provide(connection: GattConnection): NodeDataSender {
-        return if (connection.getRemoteGattService(GattlinkService.uuid) != null) {
-            Timber.d("Using GattlinkService hosted from remote device for sending data")
-            RemoteGattlinkNodeDataSender(connection)
-        } else {
-            Timber.d("Using GattlinkService hosted on local device for sending data")
-            LocalGattlinkNodeDataSender(connection, fitbitGatt)
+        return when {
+            connection.getRemoteGattService(FitbitGattlinkService.uuid) != null -> {
+                Timber.d("Using FitbitGattlink Service hosted from remote device for sending data")
+                RemoteGattlinkNodeDataSender(connection, FitbitGattlinkService.uuid)
+            }
+            connection.getRemoteGattService(GattlinkService.uuid) != null -> {
+                Timber.d("Using Gattlink Service hosted from remote device for sending data")
+                RemoteGattlinkNodeDataSender(connection, GattlinkService.uuid)
+            }
+            else -> {
+                Timber.d("Using FitbitGattlink Service hosted on local device for sending data")
+                LocalGattlinkNodeDataSender(connection, FitbitGattlinkService.uuid, fitbitGatt)
+            }
         }
     }
 

--- a/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/node/RemoteGattlinkNodeDataSender.kt
+++ b/platform/android/goldengate/GoldenGateConnectionManager/src/main/java/com/fitbit/goldengate/node/RemoteGattlinkNodeDataSender.kt
@@ -5,18 +5,21 @@ package com.fitbit.goldengate.node
 
 import com.fitbit.bluetooth.fbgatt.GattConnection
 import com.fitbit.bluetooth.fbgatt.rx.client.GattCharacteristicWriter
-import com.fitbit.goldengate.bt.gatt.server.services.gattlink.GattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.ReceiveCharacteristic
 import io.reactivex.Completable
+import java.util.UUID
 
 /**
  * Use Gattlink service hosted on connected Node GATT server for sending data via its Rx characteristic
  */
 internal class RemoteGattlinkNodeDataSender(
     private val connection: GattConnection,
+    private val serviceId: UUID,
     private val gattCharacteristicWriter: GattCharacteristicWriter = GattCharacteristicWriter(connection)
 ) : NodeDataSender {
 
     override fun send(data: ByteArray): Completable =
-        gattCharacteristicWriter.write(GattlinkService.uuid, ReceiveCharacteristic.uuid, data)
+        gattCharacteristicWriter.write(
+            serviceId,
+            ReceiveCharacteristic.uuid, data)
 }

--- a/platform/android/goldengate/GoldenGateConnectionManager/src/test/java/com/fitbit/goldengate/bt/GlobalBluetoothGattInitializerTest.kt
+++ b/platform/android/goldengate/GoldenGateConnectionManager/src/test/java/com/fitbit/goldengate/bt/GlobalBluetoothGattInitializerTest.kt
@@ -8,9 +8,8 @@ import com.fitbit.bluetooth.fbgatt.FitbitGatt
 import com.fitbit.bluetooth.fbgatt.exception.BluetoothNotEnabledException
 import com.fitbit.bluetooth.fbgatt.rx.server.BitGattServer
 import com.fitbit.goldengate.bt.gatt.GattServerListenerRegistrar
-import com.fitbit.goldengate.bt.gatt.server.services.gattcache.GattCacheService
 import com.fitbit.goldengate.bt.gatt.server.services.gattcache.GattCacheServiceHandler
-import com.fitbit.goldengate.bt.gatt.server.services.gattlink.GattlinkService
+import com.fitbit.goldengate.bt.gatt.server.services.gattlink.FitbitGattlinkService
 import com.fitbit.linkcontroller.LinkControllerProvider
 import com.nhaarman.mockitokotlin2.*
 import io.reactivex.Completable
@@ -31,7 +30,7 @@ class GlobalBluetoothGattInitializerTest {
     private val callbackCaptor = ArgumentCaptor.forClass(FitbitGatt.FitbitGattCallback::class.java)
     private val mockGattServer = mock<BitGattServer>()
     private val mockGattCacheServiceHandler = mock<GattCacheServiceHandler>()
-    private val mockGattlinkService = mock<GattlinkService>()
+    private val mockFitbitGattlinkService = mock<FitbitGattlinkService>()
 
     private val initializer = GlobalBluetoothGattInitializer(
         fitbitGatt = mockFitbitGatt,
@@ -39,7 +38,7 @@ class GlobalBluetoothGattInitializerTest {
         gattServerListenerRegistrar = mockGattServerListenerRegistrar,
         linkControllerProvider = mockLinkControllerProvider,
         gattCacheServiceHandler = mockGattCacheServiceHandler,
-        gattlinkServiceProvider = { mockGattlinkService }
+        gattlinkServiceProvider = { mockFitbitGattlinkService }
     )
 
     @Before
@@ -104,7 +103,7 @@ class GlobalBluetoothGattInitializerTest {
     private fun verifyInitGattlinkCalled() = verifyInitGattlink(1)
     private fun verifyInitGattlinkNotCalled() = verifyInitGattlink(0)
     private fun verifyInitGattlink(times: Int){
-        verify(mockGattServer, times(times)).addServices(mockGattlinkService)
+        verify(mockGattServer, times(times)).addServices(mockFitbitGattlinkService)
     }
     private fun verifyInitGattCacheServiceCalled() = verifyInitGattCacheService(1)
     private fun verifyInitGattCacheServiceNotCalled() = verifyInitGattCacheService(0)

--- a/platform/android/goldengate/GoldenGateConnectionManager/src/test/java/com/fitbit/goldengate/node/NodeDataSenderProviderTest.kt
+++ b/platform/android/goldengate/GoldenGateConnectionManager/src/test/java/com/fitbit/goldengate/node/NodeDataSenderProviderTest.kt
@@ -4,6 +4,7 @@
 package com.fitbit.goldengate.node
 
 import com.fitbit.bluetooth.fbgatt.FitbitGatt
+import com.fitbit.goldengate.bt.gatt.server.services.gattlink.FitbitGattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.GattlinkService
 import com.fitbit.goldengate.bt.mockBluetoothGattService
 import com.fitbit.goldengate.bt.mockGattConnection
@@ -18,6 +19,15 @@ class NodeDataSenderProviderTest {
     private val provider = NodeDataSenderProvider(fitbitGatt)
 
     @Test
+    fun shouldCreateRemoteSenderIfFitbitGattlinkOnRemoteDevice() {
+        whenever(mockGattConnection.getRemoteGattService(FitbitGattlinkService.uuid)).thenReturn(mockBluetoothGattService)
+
+        val receiver = provider.provide(mockGattConnection)
+
+        assertTrue(receiver is RemoteGattlinkNodeDataSender )
+    }
+
+    @Test
     fun shouldCreateRemoteSenderIfGattlinkOnRemoteDevice() {
         whenever(mockGattConnection.getRemoteGattService(GattlinkService.uuid)).thenReturn(mockBluetoothGattService)
 
@@ -28,6 +38,7 @@ class NodeDataSenderProviderTest {
 
     @Test
     fun shouldCreateLocalReceiverIfGattlinkNotOnRemoteDevice() {
+        whenever(mockGattConnection.getRemoteGattService(FitbitGattlinkService.uuid)).thenReturn(null)
         whenever(mockGattConnection.getRemoteGattService(GattlinkService.uuid)).thenReturn(null)
 
         val receiver = provider.provide(mockGattConnection)

--- a/platform/android/goldengate/app/src/main/kotlin/com/fitbit/goldengatehost/AbstractHostActivity.kt
+++ b/platform/android/goldengate/app/src/main/kotlin/com/fitbit/goldengatehost/AbstractHostActivity.kt
@@ -46,6 +46,7 @@ import com.fitbit.goldengate.bindings.stack.Stack
 import com.fitbit.goldengate.bindings.stack.StackConfig
 import com.fitbit.goldengate.bindings.stack.StackService
 import com.fitbit.goldengate.bt.PeerRole
+import com.fitbit.goldengate.bt.gatt.server.services.gattlink.FitbitGattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.GattlinkService
 import com.fitbit.goldengate.node.Peer
 import com.fitbit.goldengate.node.PeerBuilder
@@ -213,7 +214,7 @@ abstract class AbstractHostActivity<T: StackService> : AppCompatActivity() {
         disposeBag.add(
             advertiser.startAdvertising(
                 Advertiser.getAdvertiseSettings(),
-                Advertiser.getAdvertiseData(GattlinkService.uuid.toString()),
+                Advertiser.getAdvertiseData(FitbitGattlinkService.uuid.toString()),
                 Advertiser.getScanResponseData())
                 .subscribe({
                     Snackbar.make(container, "Start Advertising", Snackbar.LENGTH_SHORT).show()

--- a/platform/android/goldengate/app/src/main/kotlin/com/fitbit/goldengatehost/scan/ScanFragment.kt
+++ b/platform/android/goldengate/app/src/main/kotlin/com/fitbit/goldengatehost/scan/ScanFragment.kt
@@ -15,11 +15,13 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import com.fitbit.bluetooth.fbgatt.GattConnection
+import com.fitbit.bluetooth.fbgatt.rx.DEFAULT_UUID_MASK
 import com.fitbit.bluetooth.fbgatt.rx.GOLDEN_GATE_SERVICE_UUID_MASK
 import com.fitbit.bluetooth.fbgatt.rx.KnownGattConnectionFinder
 import com.fitbit.bluetooth.fbgatt.rx.scanner.PeripheralScanner
 import com.fitbit.bluetooth.fbgatt.rx.scanner.PeripheralScanner.ScanEvent.Discovered
 import com.fitbit.bluetooth.fbgatt.rx.scanner.ServiceUuidPeripheralScannerFilter
+import com.fitbit.goldengate.bt.gatt.server.services.gattlink.FitbitGattlinkService
 import com.fitbit.goldengate.bt.gatt.server.services.gattlink.GattlinkService
 import com.fitbit.goldengatehost.R
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -111,9 +113,12 @@ class ScanFragment : Fragment() {
         )
     }
 
-    private fun scanFilter() = listOf(gattlinkServiceFilter())
+    private fun scanFilter() = listOf(gattlinkServiceFilter(), fitbitGattlinkServiceFilter())
 
     private fun gattlinkServiceFilter() =
         ServiceUuidPeripheralScannerFilter(ParcelUuid(GattlinkService.uuid), ParcelUuid.fromString(GOLDEN_GATE_SERVICE_UUID_MASK))
+
+    private fun fitbitGattlinkServiceFilter() =
+        ServiceUuidPeripheralScannerFilter(ParcelUuid(FitbitGattlinkService.uuid), ParcelUuid.fromString(DEFAULT_UUID_MASK))
 
 }


### PR DESCRIPTION
Summary:
1. update scan filter to support public gattlink service uuid
2. update linkup logic to handle both legacy gattlink and fitbit gattlink services
3. update Node mode to use fitbit gattlink service uuid in adv payload.

Test Plan:
1. verify gg connection setup with gg host central and peripheral modes
2. verify gg host app still works fine with existing fitbit trackers
3. verify gg host app can create connection with modified fitbit atlas tracker, which is sending new fitbit gattlink service uuid.