### PR TITLE
update the ndk reference

### DIFF
--- a/docs/src/platforms/android.md
+++ b/docs/src/platforms/android.md
@@ -41,6 +41,9 @@ Platform-Tools, Android Support Library, LLDB, CMake, Android SDK
 Build-Tools, and everything under the Support Library header. You can skip
 the emulator images to save some disk space.
 
+Check the project's gradle files to see which version of the NDK is referenced
+(the current version should be: 21.0.6113669)
+
 Alternatively, on Linux, you can install the SDK components from the command line:
 
 ```bash
@@ -52,7 +55,7 @@ $ sdk/tools/bin/sdkmanager \
     'platforms;android-27' \
     'platforms;android-28' \
     'platforms;android-29' \
-    'ndk-bundle' \
+    'ndk;21.0.6113669' \
     'cmake;3.6.4111459' \
     'lldb;3.0' \
     'build-tools;27.0.3' \

--- a/tasks/android/library.py
+++ b/tasks/android/library.py
@@ -37,7 +37,8 @@ the SDK manager.
     else:
         profiles = [profile]
 
-    toolchain = "{}/ndk-bundle/build/cmake/android.toolchain.cmake".format(ctx.android.sdk)
+    ndk_version = "21.0.6113669"
+    toolchain = "{}/ndk/{}/build/cmake/android.toolchain.cmake".format(ctx.android.sdk, ndk_version)
     generator = "'Android Gradle - Ninja'"
 
     for arch in profiles:


### PR DESCRIPTION
The NDK bundle method is deprecated, so move to the new NDK "side by side" mode