### PR TITLE
[iOS] Update RxSwift to 5.1.2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
 # External
 github "Polidea/RxBluetoothKit" "e9f46b51fb3f1bf9d9b967c176866c9fae77c540"
-github "ReactiveX/RxSwift" ~> 5.1.1
+github "ReactiveX/RxSwift" == 5.1.2
 github "fpillet/NSLogger" == 1.9.7
 github "daltoniam/Starscream" "a2ed45c0b2f996cb8c335c4f270ecc68c3bd4c0f"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "Polidea/RxBluetoothKit" "e9f46b51fb3f1bf9d9b967c176866c9fae77c540"
 github "Quick/Nimble" "v9.0.0"
 github "Quick/Quick" "v3.0.0"
-github "ReactiveX/RxSwift" "5.1.1"
+github "ReactiveX/RxSwift" "5.1.2"
 github "daltoniam/Starscream" "a2ed45c0b2f996cb8c335c4f270ecc68c3bd4c0f"
 github "fpillet/NSLogger" "v1.9.7"


### PR DESCRIPTION
This is the first change that enables building GoldenGate iOS with Xcode 12.5.

From Xcode 12.5 Release notes:
```
Xcode no longer includes XCTest’s legacy Swift overlay library (libswiftXCTest.dylib).
Use the library’s replacement, libXCTestSwiftSupport.dylib, instead. For frameworks
that encounter build issues because of the removal of the legacy library, delete the
framework and library search paths for libswiftXCTest.dylib and add the
ENABLE_TESTING_SEARCH_PATHS=YES build setting.

This setting automatically sets the target’s search paths so that it can locate the
replacement XCTest library.
```

RxSwift 5.1.2 addresses this issue and enables building with Xcode 12.5.