### PR TITLE
[iOS] Enable Xcode 12.5 building

### DIFF
--- a/external/rxbit/Cartfile
+++ b/external/rxbit/Cartfile
@@ -1,2 +1,2 @@
 # External
-github "ReactiveX/RxSwift" == 5.1.1
+github "ReactiveX/RxSwift" == 5.1.2

--- a/external/rxbit/Cartfile.resolved
+++ b/external/rxbit/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v9.0.0"
 github "Quick/Quick" "v3.0.0"
-github "ReactiveX/RxSwift" "5.1.1"
+github "ReactiveX/RxSwift" "5.1.2"

--- a/tasks/apple/carthage.py
+++ b/tasks/apple/carthage.py
@@ -84,7 +84,9 @@ def _carthage_setup_environment():
     # See https://github.com/Carthage/Carthage/issues/3019 for more details
     fp = NamedTemporaryFile(delete=False, prefix='static.xcconfig.')
     fp.write(b'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8\n')
-    fp.write(b'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))')
+    fp.write(b'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))\n')
+    fp.write(b'ENABLE_TESTING_SEARCH_PATHS=YES\n')
+    fp.write(b'OTHER_LDFLAGS=""\n')
     fp.close()
 
     handler = lambda a, b: os.unlink(fp.name)


### PR DESCRIPTION
From the Xcode 12.5 release notes[0]:
```
Xcode no longer includes XCTest’s legacy Swift overlay library (libswiftXCTest.dylib).
Use the library’s replacement, libXCTestSwiftSupport.dylib, instead. For frameworks
that encounter build issues because of the removal of the legacy library, delete the
framework and library search paths for libswiftXCTest.dylib and add the
ENABLE_TESTING_SEARCH_PATHS=YES build setting.
This setting automatically sets the target’s search paths so that it can locate the
replacement XCTest library. (70365050)
```

Use the same approach as RxSwift [1] and set the `ENABLE_TESTING_SEARCH_PATHS=YES`
build setting together with `OTHER_LDFLAGS=""` when building our 3rd party dependencies
with Carthage.

[0] https://developer.apple.com/documentation/xcode-release-notes/xcode-12_5-release-notes
[1] https://github.com/ReactiveX/RxSwift/commit/89c038d2f30b142d19ff4c29baa9d00fb58699ee