### PR TITLE
change the lwip submodule URL to point to a public mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/lwip"]
 	path = external/lwip
-	url = https://git.savannah.nongnu.org/git/lwip.git
+	url = https://github.com/lwip-tcpip/lwip.git
 [submodule "external/mbedtls"]
 	path = external/mbedtls
 	url = https://github.com/ARMmbed/mbedtls.git


### PR DESCRIPTION
The server for https://git.savannah.nongnu.org/git/lwip.git is not very reliable, to instead we point to a public mirror of the LwIP repo on GitHub
