### PR TITLE
Accomodate for mbedTLS api changes for SSL record size getter

### DIFF
--- a/xp/tls/ports/mbedtls/gg_mbedtls_tls.c
+++ b/xp/tls/ports/mbedtls/gg_mbedtls_tls.c
@@ -119,7 +119,7 @@ static void GG_DtlsProtocol_TransportSide_TryToFlush(GG_DtlsProtocol* self);
 /*----------------------------------------------------------------------
 |   2.x/3.x compatibility
 +---------------------------------------------------------------------*/
-#if MBEDTLS_VERSION_NUMBER < 0x03000000
+#if MBEDTLS_VERSION_NUMBER < 0x020d0000
 #define mbedtls_ssl_get_max_out_record_payload mbedtls_ssl_get_max_frag_len
 #endif
 
@@ -862,11 +862,13 @@ GG_DtlsProtocol_Create(GG_TlsProtocolRole   role,
     GG_Result result;
 
     GG_LOG_FINE("GG_DtlsProtocol_Create, sizeof(GG_DtlsProtocol) = %u", (int)sizeof(GG_DtlsProtocol));
+#if defined(MBEDTLS_VERSION_C)
     char mbedtls_version_string[12];
     mbedtls_version_get_string(mbedtls_version_string);
     GG_LOG_FINE("MbedTLS compile time version = %s, runtime version = %s",
                 MBEDTLS_VERSION_STRING,
                 mbedtls_version_string);
+#endif
 
     // check the arguments
     if (max_datagram_size < GG_DTLS_MIN_DATAGRAM_SIZE ||


### PR DESCRIPTION
- Since version 2.22 `mbedtls_ssl_get_max_frag_len` is no longer supported. Yet `mbedtls_ssl_get_max_out_record_payload` has been supported since 2.13 and is available in 3.x. Uodated the compile time check to version 2.13 to use the new api for all the new versions maintaining backward compatibility.
- Added compile time gate for mbedTLS library version log for the configs that don't have `MBEDTLS_VERSION_C` enabled.