### PR TITLE
Define MBEDTLS_ALLOW_PRIVATE_ACCESS only if not already defined

### DIFF
--- a/xp/tls/ports/mbedtls/gg_mbedtls_tls.c
+++ b/xp/tls/ports/mbedtls/gg_mbedtls_tls.c
@@ -24,7 +24,9 @@
 
 #include "mbedtls/version.h"
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
+#if !defined(MBEDTLS_ALLOW_PRIVATE_ACCESS)
 #define MBEDTLS_ALLOW_PRIVATE_ACCESS // Needed to access mbedtls_ssl_context.state
+#endif
 #endif
 
 #include "mbedtls/ssl.h"


### PR DESCRIPTION
Define MBEDTLS_ALLOW_PRIVATE_ACCESS only if not already defined, to avoid build failures in some environments