### PR TITLE
report timer pool exhaustion with appropriate error code

### DIFF
--- a/xp/coap/gg_coap_endpoint.c
+++ b/xp/coap/gg_coap_endpoint.c
@@ -352,7 +352,7 @@ GG_CoapRequestContext_Create(GG_CoapEndpoint*               endpoint,
     GG_Result result = GG_TimerScheduler_CreateTimer(endpoint->timer_scheduler, &self->resend_timer);
     if (GG_FAILED(result)) {
         GG_FreeMemory(self);
-        return GG_ERROR_OUT_OF_MEMORY;
+        return result;
     }
 
     // setup the interface

--- a/xp/common/gg_timer.c
+++ b/xp/common/gg_timer.c
@@ -20,6 +20,7 @@
 #include "xp/common/gg_memory.h"
 #include "xp/common/gg_port.h"
 #include "xp/common/gg_timer.h"
+#include "xp/common/gg_logging.h"
 
 /*----------------------------------------------------------------------
 |   constants
@@ -27,6 +28,11 @@
 #if !defined(GG_CONFIG_MAX_TIMERS)
 #define GG_CONFIG_MAX_TIMERS 32
 #endif
+
+/*----------------------------------------------------------------------
+|   logging
++---------------------------------------------------------------------*/
+GG_SET_LOCAL_LOGGER("gg.xp.common.timer")
 
 /*----------------------------------------------------------------------
 |   types
@@ -106,6 +112,7 @@ GG_TimerScheduler_CreateTimer(GG_TimerScheduler* self, GG_Timer** timer)
 
     // check that we have a timer available
     if (GG_LINKED_LIST_IS_EMPTY(&self->nursery)) {
+        GG_LOG_WARNING("timer pool empty");
         *timer = NULL;
         return GG_ERROR_OUT_OF_RESOURCES;
     }


### PR DESCRIPTION
When failing to create a timer for a new CoAP request, return the underlying error code (`GG_ERROR_OUT_OF_RESOURCES`) rather than `GG_ERROR_OUT_OF_MEMORY`.