### PR TITLE
Fix for CoapEndpointSpec test when transport becomes not ready

### DIFF
--- a/platform/apple/bindings/GoldenGate/Coap/Spec/CoapEndpointSpec.swift
+++ b/platform/apple/bindings/GoldenGate/Coap/Spec/CoapEndpointSpec.swift
@@ -138,7 +138,14 @@ final class CoapEndpointSpec: QuickSpec {
                 }
             }
 
-            xit("rejects requests when transport becomes not ready after requests started") {
+            it("rejects requests when transport becomes not ready after requests started") {
+                
+                // For this test, we want to use a response that will not return during the timeout
+                // so that we give plenty of time for the .notReady signal to be sent
+                let response = Observable.just(message)
+                    .delay(.seconds(20), scheduler: MainScheduler.instance).asSingle()
+                transferStrategy.respondWith(response)
+                
                 transportReadiness = Observable.just(.ready)
                     .concat(
                         Observable.just(.notReady(reason: TestError.transportNotReady))


### PR DESCRIPTION
This PR updates the test `rejects requests when transport becomes not ready after requests started` to change the response delay time which fixes the race condition.

By setting the response to return after the test timeout, we ensure that the test has enough time to receive the notReady signal. Otherwise you can get an incorrect response due to the notReady signal and default response time being very close. This doesn't increase the time the test will run because the notReady signal is sent in 20ms. The longest time this test could run is 10s, but that is only if the signal fails to be sent and captured correctly (aka a completely broken test).

This PR also re-enables the test so it will start executing on the CI.