### PR TITLE
Add transaction name, result status, and response code in error string

### DIFF
--- a/platform/android/goldengate/RxFitbitGatt/src/main/java/com/fitbit/bluetooth/fbgatt/rx/GattTransactionExt.kt
+++ b/platform/android/goldengate/RxFitbitGatt/src/main/java/com/fitbit/bluetooth/fbgatt/rx/GattTransactionExt.kt
@@ -26,7 +26,8 @@ fun GattClientTransaction.runTxReactive(gattConnection: GattConnection): Single<
                 emitter.onSuccess(result)
             } else {
                 Timber.w("Running GattTransaction ${this.name} failed, result: $result")
-                emitter.onError(GattTransactionException(result, "${result.resultStatus}"))
+                val message = "TransactionName: ${result.transactionName} ResultStatus: ${result.resultStatus.name} ResponseStatus: ${result.responseCodeString}"
+                emitter.onError(GattTransactionException(result, message))
             }
         }
     }
@@ -46,7 +47,8 @@ fun GattServerTransaction.runTxReactive(gattServerConnection: GattServerConnecti
                 emitter.onSuccess(result)
             } else {
                 Timber.w("Running GattTransaction ${this.name} failed, result: $result")
-                emitter.onError(GattTransactionException(result, "${result.resultStatus}"))
+                val message = "TransactionName: ${result.transactionName} ResultStatus: ${result.resultStatus.name} ResponseStatus: ${result.responseCodeString}"
+                emitter.onError(GattTransactionException(result, message))
             }
         }
     }


### PR DESCRIPTION
Add more information to GattTransactionException. This adds the response code string which should tell us _why_ it failed. It will also add the transaction name.

