### PR TITLE
Update version of CMake to support latest macOS

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - python=3.9.15
 - invoke=1.3
 - semver=2.8.1
-- cmake=3.19
+- cmake=3.23
 - git=2.34.1
 # Note: Replace line below with - xpack-gcc-arm-none-eabi=11.2.1.1.2 for Apple Silicon setup. Proper solution pending.
 - gcc-arm-none-eabi=8.2019.q3.update


### PR DESCRIPTION
This PR updates the version of CMake that works on the latest version of macOS that we are using in the GitHub actions. This should fix the broken macOS build.