### PR TITLE
fix some compiler warnings with new versions of Clang

### DIFF
--- a/xp/CMakeLists.txt
+++ b/xp/CMakeLists.txt
@@ -63,7 +63,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Weverything -Wint-conversion -Wno-padded -Wno-sign-conversion -Wno-extended-offsetof
     -Wno-documentation-unknown-command -Wno-documentation-deprecated-sync -Wno-missing-field-initializers
     -Wno-missing-noreturn -Wno-c99-extensions -Wno-vla -Wno-date-time -Wno-unknown-warning-option -Wno-disabled-macro-expansion -fno-common
-    -Wno-missing-braces)
+    -Wno-missing-braces -Wno-declaration-after-statement)
     if(CMAKE_OSX_SYSROOT)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lobjc")
     endif()

--- a/xp/apps/stack-tool/gg_stack_tool_core_bluetooth_transport.m
+++ b/xp/apps/stack-tool/gg_stack_tool_core_bluetooth_transport.m
@@ -691,7 +691,7 @@ didUpdateValueForCharacteristic: (CBCharacteristic *)characteristic
     } else if ([characteristic.UUID isEqual:
                    [CBUUID UUIDWithString: GG_LINK_STATUS_CONNECTION_CONFIGURATION_CHARACTERISTIC_UUID]]) {
         GG_LOG_FINE("got value for the Link Status Connection Configuration Charateristic");
-        if (characteristic.value == nil | characteristic.value.length < 9) {
+        if (characteristic.value == nil || characteristic.value.length < 9) {
             GG_LOG_WARNING("characteristic value too short");
             return;
         }
@@ -733,7 +733,7 @@ didUpdateValueForCharacteristic: (CBCharacteristic *)characteristic
     } else if ([characteristic.UUID isEqual:
                    [CBUUID UUIDWithString: GG_LINK_STATUS_CONNECTION_STATUS_CHARACTERISTIC_UUID]]) {
         GG_LOG_FINE("got value for the Link Status Connection Status characteristic");
-        if (characteristic.value == nil | characteristic.value.length < 7) {
+        if (characteristic.value == nil || characteristic.value.length < 7) {
             GG_LOG_WARNING("characteristic value too short");
             return;
         }

--- a/xp/coap/gg_coap.h
+++ b/xp/coap/gg_coap.h
@@ -246,7 +246,7 @@ GG_DECLARE_INTERFACE(GG_CoapRequestHandler) {
      * @param responder The responder object that may be used to respond asynchronously.
      * This parameter is NULL if the handler wasn't registered with the
      * GG_COAP_REQUEST_HANDLER_FLAG_ENABLE_ASYNC flag set.
-     * @param tansport_metadata Metadata associated with the transport from which the request
+     * @param transport_metadata Metadata associated with the transport from which the request
      * was received (typically of type GG_BUFFER_METADATA_TYPE_SOURCE_SOCKET_ADDRESS if the transport
      * is a UDP socket). May be NULL if no metadata exists for the request.
      * @param response Pointer to the variable where the handler should return its response.

--- a/xp/common/gg_inspect.h
+++ b/xp/common/gg_inspect.h
@@ -138,7 +138,7 @@ struct GG_InspectableInterface {
      *
      * @param self The object on which this method is invoked.
      * @param inspector The inspector that should be called back during the inspection.
-     * @param options. Options for the inspection. May be NULL when no specific option is needed.
+     * @param options Options for the inspection. May be NULL when no specific option is needed.
      *
      * @return GG_SUCCESS if the call succeeded, or a negative error code.
      */

--- a/xp/examples/interfaces/gg_interfaces_example.c
+++ b/xp/examples/interfaces/gg_interfaces_example.c
@@ -89,7 +89,7 @@ GG_Accumulator_GetValue(const GG_Accumulator* self)
 // usage example for Example 1
 //
 static void
-Example1()
+Example1(void)
 {
     printf("* Example 1\n");
 
@@ -321,7 +321,7 @@ GG_IMPLEMENT_INTERFACE(SimpleVisitor, GG_ShapeVisitor) {
 };
 
 static void
-Example2()
+Example2(void)
 {
     printf("* Example 2\n");
 
@@ -396,7 +396,7 @@ GG_IMPLEMENT_INTERFACE(ToStringVisitor, GG_ShapeVisitor) {
 };
 
 static void
-Example3()
+Example3(void)
 {
     printf("* Example 3\n");
 

--- a/xp/tls/gg_tls.h
+++ b/xp/tls/gg_tls.h
@@ -114,7 +114,7 @@ GG_DECLARE_INTERFACE(GG_TlsKeyResolver) {
      */
     GG_Result (*ResolveKey)(GG_TlsKeyResolver* self,
                             const uint8_t*     key_identity,
-                            size_t             key_identify_size,
+                            size_t             key_identity_size,
                             uint8_t*           key,
                             size_t*            key_size);
 };


### PR DESCRIPTION
Recent versions of Clang produce new warnings that were not there before. This PR fixes those warnings, except in 3rd party submodules.