### PR TITLE
clamp gattlink mtu

### DIFF
--- a/xp/gattlink/gg_gattlink.c
+++ b/xp/gattlink/gg_gattlink.c
@@ -652,8 +652,9 @@ GG_GattlinkProtocol_PrepareNextPacket(GG_GattlinkProtocol* self,
                                       size_t*              buf_len,
                                       size_t*              payload_size)
 {
-    size_t max_packet_size = GG_GattlinkClient_GetTransportMaxPacketSize(self->client);
-    GG_ASSERT(max_packet_size  >= sizeof(GG_GattlinkResetCompletePacket));
+    size_t max_packet_size = GG_MIN(GG_GattlinkClient_GetTransportMaxPacketSize(self->client),
+                                    GG_GATTLINK_MAX_PACKET_SIZE);
+    GG_ASSERT(max_packet_size >= sizeof(GG_GattlinkResetCompletePacket));
 
     // we want to ACK data before the other side is blocked waiting for an ACK
     bool ack_now = self->out.ack_now;

--- a/xp/gattlink/gg_gattlink.c
+++ b/xp/gattlink/gg_gattlink.c
@@ -768,6 +768,7 @@ GG_GattlinkProtocol_OnAckTimerFired(GG_GattlinkProtocol* self, uint32_t elapsed)
     GG_COMPILER_UNUSED(elapsed);
 
     // We haven't sent any ack in our specified period
+    GG_LOG_FINEST("ACK timer fired");
     self->out.ack_now = true;
     GG_GattlinkProtocol_SendNextPackets(self);
 }

--- a/xp/stack_builder/gg_stack_builder.c
+++ b/xp/stack_builder/gg_stack_builder.c
@@ -244,7 +244,7 @@ GG_StackGattlinkElement_OnLinkMtuChange(GG_StackGattlinkElement*          self,
     if (self->max_transport_fragment_size_limit &&
         max_transport_fragment_size > self->max_transport_fragment_size_limit) {
         max_transport_fragment_size = self->max_transport_fragment_size_limit;
-        GG_LOG_FINE("clamping max transport fragment size to %u", max_transport_fragment_size);
+        GG_LOG_FINE("clamping max transport fragment size to %d", (int)max_transport_fragment_size);
     }
     GG_GattlinkGenericClient_SetMaxTransportFragmentSize(self->client, max_transport_fragment_size);
 }
@@ -318,10 +318,14 @@ GG_StackGattlinkElement_Create(const GG_StackElementGattlinkParameters* paramete
     } else {
         gattlink_buffer_size = 2 * stack->ip_configuration.ip_mtu; // default to 2 max IP packets
         if (!parameters || !parameters->tx_window) {
-            // using default tx window size, pick an mtu limit that ensures we will not underflow
-            // the window given this buffer size
-            self->max_fragment_size_limit = gattlink_buffer_size /
-                                            (2 + GG_GENERIC_GATTLINK_CLIENT_DEFAULT_MAX_TX_WINDOW_SIZE);
+            // We are using the default tx window size.
+            // Pick an mtu limit that ensures we will not underflow the window given this buffer size.
+            // The heuristic is: pick a limit such that one IP packet will fit in 1 more than 1/2
+            // tx_window buffers. This is because the peer will always ACK a packet that's past 1/2
+            // the window size, without waiting, even if it has nothing to send. Up to 1/2 of the window,
+            // it will wait up to some configured timeout (200ms by default) before sending an ACK.
+            self->max_transport_fragment_size_limit = stack->ip_configuration.ip_mtu /
+                                                      ( 1 + GG_GENERIC_GATTLINK_CLIENT_DEFAULT_MAX_TX_WINDOW_SIZE / 2);
         }
     }
     GG_LOG_FINE("creating gattlink client - buffer_size=%d, tx_window=%d, rx_window=%d, initial_max_fragment_size=%d",

--- a/xp/stack_builder/gg_stack_builder.c
+++ b/xp/stack_builder/gg_stack_builder.c
@@ -240,7 +240,13 @@ static void
 GG_StackGattlinkElement_OnLinkMtuChange(GG_StackGattlinkElement*          self,
                                         const GG_StackLinkMtuChangeEvent* event)
 {
-    GG_GattlinkGenericClient_SetMaxTransportFragmentSize(self->client, (size_t)event->link_mtu);
+    size_t max_transport_fragment_size = (size_t)event->link_mtu;
+    if (self->max_transport_fragment_size_limit &&
+        max_transport_fragment_size > self->max_transport_fragment_size_limit) {
+        max_transport_fragment_size = self->max_transport_fragment_size_limit;
+        GG_LOG_FINE("clamping max transport fragment size to %u", max_transport_fragment_size);
+    }
+    GG_GattlinkGenericClient_SetMaxTransportFragmentSize(self->client, max_transport_fragment_size);
 }
 
 //----------------------------------------------------------------------
@@ -311,6 +317,12 @@ GG_StackGattlinkElement_Create(const GG_StackElementGattlinkParameters* paramete
         gattlink_buffer_size = parameters->buffer_size;
     } else {
         gattlink_buffer_size = 2 * stack->ip_configuration.ip_mtu; // default to 2 max IP packets
+        if (!parameters || !parameters->tx_window) {
+            // using default tx window size, pick an mtu limit that ensures we will not underflow
+            // the window given this buffer size
+            self->max_fragment_size_limit = gattlink_buffer_size /
+                                            (2 + GG_GENERIC_GATTLINK_CLIENT_DEFAULT_MAX_TX_WINDOW_SIZE);
+        }
     }
     GG_LOG_FINE("creating gattlink client - buffer_size=%d, tx_window=%d, rx_window=%d, initial_max_fragment_size=%d",
                 (int)gattlink_buffer_size,

--- a/xp/stack_builder/gg_stack_builder_base.h
+++ b/xp/stack_builder/gg_stack_builder_base.h
@@ -80,6 +80,7 @@ typedef struct {
     GG_Ipv4FrameSerializer*   frame_serializer;
     GG_Ipv4FrameAssembler*    frame_assembler;
     GG_GattlinkGenericClient* client;
+    size_t                    max_transport_fragment_size_limit;
 } GG_StackGattlinkElement;
 
 /**


### PR DESCRIPTION
This is an optimization when GATT MTUs are large. Since we have a default Gattlink buffer size that's kept small to avoid unnecessary latency, and with a default Gattlink window size of 8, when the GATT MTU becomes large, there's a risk of having to wait for ACKs too long:
When the peer has no data to send, it sends ACKs when either a timeout has passed (200ms by default) or the number of unacknowledged packets is > (rx_window)/2. So, if the number of packets that the sender's buffer would be split into is too small (which would happen if the packets get large), the sender may be waiting too long for ACKs.
With this PR, we introduce a limit on the max packet size when using the default buffer size and default window size (when using custom configs, the caller can decide what to do, even if sub-optimal, but we want to keep the default config optimal).
In practice, this will result in the max fragment size limit to be 256 with the current default settings (default buffer is 2560 (2*1280), and rx_window=8, and we choose the limit so that 1/2 of the buffer fits in (1+rx_window)/2, so 256 bytes. 

This change has been tested between 2 macs that negotiate an ATT MTU of 527. It does offer a small throughput improvement.
More testing should be done on other platforms, with different environment, but it should be considered a safe default for all cases.